### PR TITLE
Allow to specify the branch name where to look for merged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ For help
     bbgenlog --help
 
     > Usage: bbgenlog [options]
-	> 
+    > 
     > Options:
-	> 
-    >   -h, --help         output usage information
-    >   -o, --overwrite    regenerate the full changelog. OVERWRITES the current changelog
-    >   -i, --interactive  request username / password if not provided
+    > 
+    >   -h, --help           output usage information
+    >   -o, --overwrite      regenerate the full changelog. OVERWRITES the current changelog
+    >   -b, --branch [name]  base branch to look for merged pull requests (default: master)
+    >   -i, --interactive    request username / password if not provided


### PR DESCRIPTION
This implements issue #3 by providing the `-b` option to specify the branch where to look for merged pull requests.

 * `-b` option is added to the CLI parameters
 * "master" is the default if not specified
 * `verifySettings()` has been extended to check if a branch name is given along with the `-b` option